### PR TITLE
Fix: Whitelist Vercel Blob for Next/Image

### DIFF
--- a/config/next.config.mjs
+++ b/config/next.config.mjs
@@ -20,6 +20,11 @@ const nextConfig = {
         port: '3000',
         pathname: '/api/**',
       },
+      {
+        protocol: 'https',
+        hostname: '**.public.blob.vercel-storage.com',
+        port: '',
+      },
     ],
   },
 }

--- a/config/next.config.mjs
+++ b/config/next.config.mjs
@@ -22,7 +22,7 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: '**.public.blob.vercel-storage.com',
+        hostname: '*.public.blob.vercel-storage.com',
         port: '',
       },
     ],


### PR DESCRIPTION
## Issue
Production images fail to load because Vercel Blob domains are not whitelisted in , causing  to reject them.

## Fix
Added  to .

Required for absolute URLs generated by the recent update.