### PR TITLE
ci: verify Node 24 action majors (do not merge)

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.22.0'
 
@@ -49,7 +49,7 @@ jobs:
   #     url: ${{ steps.deploy.outputs.url }}
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Deploy to Vercel (Preview)
   #       id: deploy
@@ -70,7 +70,7 @@ jobs:
   #     url: ${{ steps.deploy.outputs.url }}
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Deploy to Vercel (Production)
   #       id: deploy


### PR DESCRIPTION
Draft PR to trigger the "Lint and Type Check" job and verify the checkout@v6 / setup-node@v6 bump before the 2026-06-16 Node 24 default cutover. Will be closed after CI passes — branch promotion still goes development → preview → main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)